### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/tcl/tcl_ext/thread/thread/win/vc/nmakehlp.c
+++ b/tcl/tcl_ext/thread/thread/win/vc/nmakehlp.c
@@ -586,7 +586,7 @@ GetVersionFromFile(
 		    ++q;
 		}
 
-		memcpy(szBuffer, p, q - p);
+		memmove(szBuffer, p, q - p);
 		szBuffer[q-p] = 0;
 		szResult = szBuffer;
 		break;
@@ -723,7 +723,7 @@ SubstituteFile(
 		    memcpy(szBuffer, szCopy, sizeof(szCopy));
 		}
 	    }
-	    printf(szBuffer);
+	    printf("%s", szBuffer);
 	}
 	
 	list_free(&substPtr);


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `SubstituteFile` that was cloned from https://github.com/tcltk/tcl but did not receive the security patch.

### Details:
Affected Function: `SubstituteFile` in `/tcl/tcl_ext/thread/thread/win/vc/nmakehlp.c`
Original Fix: https://github.com/tcltk/tcl/commit/4705dbdde2f32ff90420765cd93e7ac71d81a222


### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/tcltk/tcl/commit/4705dbdde2f32ff90420765cd93e7ac71d81a222
- CVE-2021-35331: https://nvd.nist.gov/vuln/detail/CVE-2021-35331

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
