### PR TITLE
doc: use gender-neutral language in umask(2) man page

### DIFF
--- a/xnu/bsd/man/man2/umask.2
+++ b/xnu/bsd/man/man2/umask.2
@@ -64,7 +64,7 @@ requested in file mode.
 (See
 .Xr chmod 2 ) .
 This clearing allows each user to restrict the default access
-to his files.
+to the files that they own.
 .Pp
 The default mask value is S_IWGRP | S_IWOTH (022, write access for the
 owner only).


### PR DESCRIPTION
Minor update to avoid referring to the user's files as "his files" where "the files that they own" is perhaps more precise and not significantly less natural.